### PR TITLE
Add support for reCaptcha version 2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-recaptcha "0.0.2-SNAPSHOT"
+(defproject clj-recaptcha "0.0.3-SNAPSHOT"
   :description "a Clojure client for reCAPTCHA API"
   :url "http://github.com/propan/clj-recaptcha"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [clj-http "0.7.8"]])
+                 [clj-http "0.7.8"]
+                 [org.clojure/data.json "0.2.6"]])

--- a/src/clj_recaptcha/client.clj
+++ b/src/clj_recaptcha/client.clj
@@ -1,9 +1,6 @@
 (ns clj-recaptcha.client
   (:require [clj-http.client :as client]
-            [clj-http.conn-mgr :as manager]))
-
-(def http-api  "http://www.google.com/recaptcha/api")
-(def https-api "https://www.google.com/recaptcha/api")
+            [clj-recaptcha.common :as common]))
 
 (defn- parse-response
   [^String response]
@@ -17,78 +14,33 @@
   "Verifies a user's answer for a reCAPTCHA challenge.
 
    private-key - your private key
+   challenge   - the value of recaptcha_challenge_field sent via the form
    response    - the value of recaptcha_response_field sent via the form
+   remote-ip   - the IP address of the user who solved the CAPTCHA
 
    Optional parameters:
-      :version            - version of the recaptcha protocol - 2 (default) or 1
-      :remote-ip          - the IP address of the user who solved the CAPTCHA - required version 1, optional version 2
-      :challenge          - the value of recaptcha_challenge_field sent via the form (needed for version 1 only)
       :ssl?               - use HTTPS or HTTP? (default false)
       :proxy-host         - a proxy host
       :proxy-port         - a proxy port
       :connection-manager - a connection manager to be used to speed up requests"
-  [private-key response  & {:keys [ssl? proxy-host proxy-port connection-manager version challenge remote-ip]
-                                               :or {ssl? false, version 2}}]
-  (if-not (or (and (= version 1) (empty? challenge))
-              (empty? response))
+  [private-key challenge response remote-ip & {:keys [ssl? proxy-host proxy-port connection-manager]
+                                               :or {ssl? false}}]
+  (if (and (seq challenge)
+           (seq response))
     (try
-      (let [endpoint (if ssl? https-api http-api)
-            post-v1 (fn []
-                      (let [endpoint (str endpoint "/verify")]
-                        (client/post endpoint {:form-params        {:privatekey private-key
-                                                                    :remoteip   remote-ip
-                                                                    :challenge  challenge
-                                                                    :response   response}
-                                               :proxy-host         proxy-host
-                                               :proxy-port         proxy-port
-                                               :connection-manager connection-manager})))
-
-            post-v2 (fn []
-                      (let [endpoint (str endpoint "/siteverify")
-                            form-params {:secret   private-key
-                                         :response response}
-                            form-params (if remote-ip (assoc form-params :remoteip remote-ip) form-params)]
-                        (client/post endpoint {:form-params        form-params
-                                               :proxy-host         proxy-host
-                                               :proxy-port         proxy-port
-                                               :connection-manager connection-manager})))
-
-            resp  (if (= version 2) (post-v2) (post-v1))]
+      (let [endpoint (if ssl? common/https-api common/http-api)
+            endpoint (str endpoint "/verify")
+            resp     (client/post endpoint {:form-params        {:privatekey private-key
+                                                                 :remoteip   remote-ip
+                                                                 :challenge  challenge
+                                                                 :response   response}
+                                            :proxy-host         proxy-host
+                                            :proxy-port         proxy-port
+                                            :connection-manager connection-manager})]
         (parse-response (:body resp)))
-      (catch Exception ex
+      (catch Exception _ex
         {:valid? false :error "recaptcha-not-reachable"}))
     {:valid? false :error "incorrect-captcha-sol"}))
-
-(defn create-conn-manager
-  "Creates a reusable connection manager.
-
-   It's just a shortcut for clj-http.conn-mgr/make-reusable-conn-manager.
-   
-   Example:
-       (create-conn-manager {:timeout 5 :threads 4})"
-  [opts]
-  (manager/make-reusable-conn-manager opts))
-
-(defn- to-json
-  "A JSON serializer for simple Clojure maps."
-  [o]
-  (cond
-   (string? o)
-   (str "'" o "'")
-
-   (keyword? o)
-   (name o)
-   
-   (map? o)
-   (let [obj-str (->>
-                  (for [[k v] o]
-                    (str (to-json k) ":" (to-json v)))
-                  (interpose ", ")
-                  (apply str))]
-     (str "{" obj-str "}"))
-
-   :default
-   o))
 
 
 (defn render
@@ -105,12 +57,12 @@
       :iframe-width  - the width of noscript iframe (default 500)"
   [public-key & {:keys [error ssl? noscript? display iframe-height iframe-width]
                  :or {ssl? false noscript? true iframe-height 300 iframe-width 500}}]
-  (let [endpoint (if ssl? https-api http-api)
+  (let [endpoint (if ssl? common/https-api common/http-api)
         error    (if (nil? error) "" (str "&error=" error))]
     (str (when display
-           (str "<script type='text/javascript'>var RecaptchaOptions=" (to-json display) ";</script>"))
+           (str "<script type='text/javascript'>var RecaptchaOptions=" (common/to-json display) ";</script>"))
          (str "<script type='text/javascript' src='" endpoint "/challenge?k=" public-key error "'></script>")
-         (when (true? noscript?) 
+         (when (true? noscript?)
            (str "<noscript>"
                 (str "<iframe src='" endpoint "/noscript?k=" public-key error "' height='" iframe-height "' width='" iframe-width "' frameborder='0'></iframe><br/>")
                 "<textarea name='recaptcha_challenge_field' rows='3' cols='40'></textarea>"

--- a/src/clj_recaptcha/client_v2.clj
+++ b/src/clj_recaptcha/client_v2.clj
@@ -1,0 +1,40 @@
+(ns clj-recaptcha.client-v2
+    (:require [clj-http.client :as client]
+              [clojure.data.json :as json]
+              [clj-recaptcha.common :as common]))
+
+(defn- parse-response [^String response]
+  (if (seq response)
+    (let [parsed-response (json/read-str response :key-fn keyword)
+          valid (:success parsed-response)
+          error (:error-codes parsed-response)]
+      {:valid? valid :error error})
+    {:valid? false :error "incorrect-captcha-sol"}))
+
+(defn verify
+      "Verifies a user's answer for a reCAPTCHA challenge.
+
+       secret   - your secret provided by Google when you register
+       response - the value of recaptcha_response_field sent via the form
+
+       Optional parameters:
+          :remote-ip          - the IP address of the user who solved the CAPTCHA -optional version 2
+          :proxy-host         - a proxy host
+          :proxy-port         - a proxy port
+          :connection-manager - a connection manager to be used to speed up requests"
+      [secret response & {:keys [remote-ip proxy-host proxy-port connection-manager]}]
+      (if (seq response)
+        (try
+          (let [endpoint (str common/https-api "/siteverify")
+                form-params {:secret   secret
+                             :response response}
+                form-params (if remote-ip (assoc form-params :remoteip remote-ip) form-params)
+                response (client/post endpoint {:form-params        form-params
+                                                :proxy-host         proxy-host
+                                                :proxy-port         proxy-port
+                                                :connection-manager connection-manager})]
+               (parse-response (:body response)))
+          (catch Exception _ex
+            {:valid? false :error "recaptcha-not-reachable"}))
+        {:valid? false :error "incorrect-captcha-sol"}))
+

--- a/src/clj_recaptcha/common.clj
+++ b/src/clj_recaptcha/common.clj
@@ -1,0 +1,35 @@
+(ns clj-recaptcha.common (:require  [clj-http.conn-mgr :as manager]))
+
+(def http-api  "http://www.google.com/recaptcha/api")
+(def https-api "https://www.google.com/recaptcha/api")
+
+(defn create-conn-manager
+  "Creates a reusable connection manager.
+
+   It's just a shortcut for clj-http.conn-mgr/make-reusable-conn-manager.
+
+   Example:
+       (create-conn-manager {:timeout 5 :threads 4})"
+  [opts]
+  (manager/make-reusable-conn-manager opts))
+
+(defn to-json
+  "A JSON serializer for simple Clojure maps."
+  [o]
+  (cond
+   (string? o)
+   (str "'" o "'")
+
+   (keyword? o)
+   (name o)
+
+   (map? o)
+   (let [obj-str (->>
+                   (for [[k v] o]
+                        (str (to-json k) ":" (to-json v)))
+                   (interpose ", ")
+                   (apply str))]
+        (str "{" obj-str "}"))
+
+   :default
+   o))

--- a/test/clj_recaptcha/client_test.clj
+++ b/test/clj_recaptcha/client_test.clj
@@ -3,13 +3,13 @@
             [clj-recaptcha.client :as c]))
 
 (deftest verify
-  (testing "No challenge or response is given"
-    (let [res (c/verify "KEY" nil)]
+  (testing "No challenge or response is given - version 1"
+    (let [res (c/verify "KEY" nil nil nil)]
       (is (= {:valid? false :error "incorrect-captcha-sol"} res))))
 
-  (testing "Handles exceptions"
-    (with-redefs-fn {#'clj-http.client/post (fn [url query] (throw (Exception. "Troubles!")))}
-      #(let [res (c/verify "KEY" "123")]
+  (testing "Handles exceptions - version 1"
+    (with-redefs-fn {#'clj-http.client/post (fn [_url _query] (throw (Exception. "Troubles!")))}
+      #(let [res (c/verify "KEY" "123" "678" "127.0.0.1")]
          (is (= {:valid? false :error "recaptcha-not-reachable"} res)))))
 
   (testing "Successful case - version 1"
@@ -24,23 +24,10 @@
                                                                    :connection-manager nil}))
                                                 {:status 200
                                                  :body   "true\n"}))}
-      #(let [res (c/verify "KEY" "678" :version 1 :challenge "123" :remote-ip "127.0.0.1")]
+      #(let [res (c/verify "KEY" "123" "678" "127.0.0.1")]
          (is (= {:valid? true :error nil} res)))))
 
-  (testing "Successful case - version 2"
-    (with-redefs-fn {#'clj-http.client/post (fn [url query]
-                                              (when (and (= url "http://www.google.com/recaptcha/api/siteverify")
-                                                         (= query {:form-params        {:secret "KEY"
-                                                                                        :response   "678"}
-                                                                   :proxy-host         nil
-                                                                   :proxy-port         nil
-                                                                   :connection-manager nil}))
-                                                {:status 200
-                                                 :body   "true\n"}))}
-      #(let [res (c/verify "KEY" "678")]
-         (is (= {:valid? true :error nil} res)))))
-
-  (testing "Incorrect user's input - API version 1"
+  (testing "Incorrect user's input - version 1"
     (with-redefs-fn {#'clj-http.client/post (fn [url query]
                                               (when (and (= url "http://www.google.com/recaptcha/api/verify")
                                                          (= query {:form-params        {:privatekey "KEY"
@@ -52,47 +39,27 @@
                                                                    :connection-manager :CM}))
                                                 {:status 200
                                                  :body   "false\nsome-error-code"}))}
-      #(let [res (c/verify "KEY" "678"  :version 1 :remote-ip "127.0.0.1" :challenge "123" :proxy-host "localhost"
-                                        :proxy-port 456 :connection-manager :CM)]
-        (is (= {:valid? false :error "some-error-code"} res)))))
-
-
-  (testing "Incorrect user's input - API version 2"
-    (with-redefs-fn {#'clj-http.client/post (fn [url query]
-                                              (when (and (= url "http://www.google.com/recaptcha/api/siteverify")
-                                                         (= query {:form-params        {:secret   "KEY"
-                                                                                        :response "678"}
-                                                                   :proxy-host         "localhost"
-                                                                   :proxy-port         456
-                                                                   :connection-manager :CM}))
-                                                {:status 200
-                                                 :body   "false\nsome-error-code"}))}
-      #(let [res (c/verify "KEY" "678" :proxy-host "localhost" :proxy-port 456 :connection-manager :CM)]
+      #(let [res (c/verify "KEY" "123" "678" "127.0.0.1" :proxy-host "localhost" :proxy-port 456 :connection-manager :CM)]
          (is (= {:valid? false :error "some-error-code"} res))))))
 
-(deftest create-conn-manager-test
-  (with-redefs-fn {#'clj-http.conn-mgr/make-reusable-conn-manager (fn [opts]
-                                                                    (when (= opts {:threads 5})
-                                                                      :ok))}
-    #(is (= :ok (c/create-conn-manager {:threads 5})))))
 
 (deftest render-test
-  (testing "Render with default parameters"
+  (testing "Render with default parameters  - version 1"
     (let [res (c/render "234KEY")]
       (is (true? (.contains res "http://www.google.com/recaptcha/api/noscript?k=234KEY")))
       (is (true? (.contains res "http://www.google.com/recaptcha/api/challenge?k=234KEY")))))
 
-  (testing "Render with ssl and no noscript section"
+  (testing "Render with ssl and no noscript section  - version 1"
     (let [res (c/render "234KEY" :ssl? true :noscript? false)]
       (is (false? (.contains res "http://www.google.com/recaptcha/api/noscript?k=234KEY")))
       (is (true? (.contains res "https://www.google.com/recaptcha/api/challenge?k=234KEY")))))
 
-  (testing "Render with error and no noscript section"
+  (testing "Render with error and no noscript section  - version 1"
     (let [res (c/render "234KEY" :error "recaptcha-not-reachable" :noscript? false)]
       (is (false? (.contains res "http://www.google.com/recaptcha/api/noscript?k=234KEY")))
       (is (true? (.contains res "http://www.google.com/recaptcha/api/challenge?k=234KEY&error=recaptcha-not-reachable")))))
 
-  (testing "Render with theming"
+  (testing "Render with theming  - version 1"
     (let [res (c/render "234KEY" :display {:theme "clean" :lang "de"} :iframe-height 111 :iframe-width 222)]
       (is (true? (.contains res "RecaptchaOptions")))
       (is (true? (.contains res "height='111'")))

--- a/test/clj_recaptcha/client_test.clj
+++ b/test/clj_recaptcha/client_test.clj
@@ -4,15 +4,15 @@
 
 (deftest verify
   (testing "No challenge or response is given"
-    (let [res (c/verify "KEY" nil nil nil)]
+    (let [res (c/verify "KEY" nil)]
       (is (= {:valid? false :error "incorrect-captcha-sol"} res))))
 
   (testing "Handles exceptions"
     (with-redefs-fn {#'clj-http.client/post (fn [url query] (throw (Exception. "Troubles!")))}
-      #(let [res (c/verify "KEY" "123" "678" "127.0.0.1")]
+      #(let [res (c/verify "KEY" "123")]
          (is (= {:valid? false :error "recaptcha-not-reachable"} res)))))
-  
-  (testing "Successful case"
+
+  (testing "Successful case - version 1"
     (with-redefs-fn {#'clj-http.client/post (fn [url query]
                                               (when (and (= url "http://www.google.com/recaptcha/api/verify")
                                                          (= query {:form-params        {:privatekey "KEY"
@@ -24,10 +24,23 @@
                                                                    :connection-manager nil}))
                                                 {:status 200
                                                  :body   "true\n"}))}
-      #(let [res (c/verify "KEY" "123" "678" "127.0.0.1")]
+      #(let [res (c/verify "KEY" "678" :version 1 :challenge "123" :remote-ip "127.0.0.1")]
          (is (= {:valid? true :error nil} res)))))
-  
-  (testing "Incorrect user's input"
+
+  (testing "Successful case - version 2"
+    (with-redefs-fn {#'clj-http.client/post (fn [url query]
+                                              (when (and (= url "http://www.google.com/recaptcha/api/siteverify")
+                                                         (= query {:form-params        {:secret "KEY"
+                                                                                        :response   "678"}
+                                                                   :proxy-host         nil
+                                                                   :proxy-port         nil
+                                                                   :connection-manager nil}))
+                                                {:status 200
+                                                 :body   "true\n"}))}
+      #(let [res (c/verify "KEY" "678")]
+         (is (= {:valid? true :error nil} res)))))
+
+  (testing "Incorrect user's input - API version 1"
     (with-redefs-fn {#'clj-http.client/post (fn [url query]
                                               (when (and (= url "http://www.google.com/recaptcha/api/verify")
                                                          (= query {:form-params        {:privatekey "KEY"
@@ -39,7 +52,22 @@
                                                                    :connection-manager :CM}))
                                                 {:status 200
                                                  :body   "false\nsome-error-code"}))}
-      #(let [res (c/verify "KEY" "123" "678" "127.0.0.1" :proxy-host "localhost" :proxy-port 456 :connection-manager :CM)]
+      #(let [res (c/verify "KEY" "678"  :version 1 :remote-ip "127.0.0.1" :challenge "123" :proxy-host "localhost"
+                                        :proxy-port 456 :connection-manager :CM)]
+        (is (= {:valid? false :error "some-error-code"} res)))))
+
+
+  (testing "Incorrect user's input - API version 2"
+    (with-redefs-fn {#'clj-http.client/post (fn [url query]
+                                              (when (and (= url "http://www.google.com/recaptcha/api/siteverify")
+                                                         (= query {:form-params        {:secret   "KEY"
+                                                                                        :response "678"}
+                                                                   :proxy-host         "localhost"
+                                                                   :proxy-port         456
+                                                                   :connection-manager :CM}))
+                                                {:status 200
+                                                 :body   "false\nsome-error-code"}))}
+      #(let [res (c/verify "KEY" "678" :proxy-host "localhost" :proxy-port 456 :connection-manager :CM)]
          (is (= {:valid? false :error "some-error-code"} res))))))
 
 (deftest create-conn-manager-test
@@ -68,6 +96,6 @@
     (let [res (c/render "234KEY" :display {:theme "clean" :lang "de"} :iframe-height 111 :iframe-width 222)]
       (is (true? (.contains res "RecaptchaOptions")))
       (is (true? (.contains res "height='111'")))
-      (is (true? (.contains res "width='222'")))      
+      (is (true? (.contains res "width='222'")))
       (is (true? (.contains res "http://www.google.com/recaptcha/api/noscript?k=234KEY")))
       (is (true? (.contains res "http://www.google.com/recaptcha/api/challenge?k=234KEY"))))))

--- a/test/clj_recaptcha/client_v2_test.clj
+++ b/test/clj_recaptcha/client_v2_test.clj
@@ -1,0 +1,49 @@
+(ns clj-recaptcha.client-v2-test
+    (:require [clojure.test :refer :all]
+      [clj-recaptcha.client-v2 :as c]))
+
+(deftest parse-response-test
+  (let [parse-response #'c/parse-response]
+    (testing "Recognises valid response"
+      (let [res (parse-response "{\"success\" : true}")]
+        (is (= {:valid? true, :error nil} res))))
+
+    (testing "Recognises invalid response"
+      (let [res (parse-response "{\"success\" : false ,\"error-codes\": [ \"invalid-input-secret\"]}")]
+        (is (= {:valid? false, :error ["invalid-input-secret"]} res))))))
+
+(deftest verify
+  (testing "No challenge or response is given - version 2"
+    (let [res (c/verify "KEY" nil)]
+         (is (= {:valid? false :error "incorrect-captcha-sol"} res))))
+
+  (testing "Handles exceptions - version 2"
+    (with-redefs-fn {#'clj-http.client/post (fn [_url _query] (throw (Exception. "Troubles!")))}
+                     #(let [res (c/verify "KEY" "123")]
+                          (is (= {:valid? false :error "recaptcha-not-reachable"} res)))))
+
+  (testing "Successful case - version 2"
+    (with-redefs-fn {#'clj-http.client/post (fn [url query]
+                                              (when (and (= url "https://www.google.com/recaptcha/api/siteverify")
+                                                         (= query {:form-params        {:secret   "KEY"
+                                                                                        :response "678"}
+                                                                   :proxy-host         nil
+                                                                   :proxy-port         nil
+                                                                   :connection-manager nil}))
+                                                {:status 200
+                                                 :body   "{\"success\" : true}\n"}))}
+                    #(let [res (c/verify "KEY" "678")]
+                          (is (= {:valid? true :error nil} res)))))
+
+  (testing "Incorrect user's input - API version 2"
+    (with-redefs-fn {#'clj-http.client/post (fn [url query]
+                                             (when (and (= url "https://www.google.com/recaptcha/api/siteverify")
+                                                        (= query {:form-params        {:secret   "KEY"
+                                                                                       :response "678"}
+                                                                  :proxy-host         "localhost"
+                                                                  :proxy-port         456
+                                                                  :connection-manager :CM}))
+                                                   {:status 200
+                                                    :body   "{\"success\" : false ,\"error-codes\": [ \"some-error-code\"]}"}))}
+                 #(let [res (c/verify "KEY" "678" :proxy-host "localhost" :proxy-port 456 :connection-manager :CM)]
+                       (is (= {:valid? false :error ["some-error-code"]} res))))))

--- a/test/clj_recaptcha/common_test.clj
+++ b/test/clj_recaptcha/common_test.clj
@@ -1,0 +1,10 @@
+(ns clj-recaptcha.common-test
+    (:require [clojure.test :refer :all]
+              [clj-recaptcha.common :as c]))
+
+(deftest create-conn-manager-test
+  (with-redefs-fn {#'clj-http.conn-mgr/make-reusable-conn-manager (fn [opts]
+                                                                      (when (= opts {:threads 5})
+                                                                                     :ok))}
+                  #(is (= :ok (c/create-conn-manager {:threads 5})))))
+


### PR DESCRIPTION
Following changes made:

1) New namespace containing code to validate reCaptcha v2 request.
2) reCaptcha v2 code parses the JSON response - missed that first time around. To parse the json - I have added Clojure data json as a dependency - hope this is ok
3) Additional unit tests to check the json parsing
4)Version 1 code - fixed a minor bug where response or secret are null
5)Version 1 code - fixed unused parameter warnings
6) Version 1 code - added version 1 to tests so clear which test is failing 